### PR TITLE
fix: remove trailing whitespace in SQL table definition in README and…

### DIFF
--- a/examples/with-vector-search/README.md
+++ b/examples/with-vector-search/README.md
@@ -55,7 +55,7 @@ CREATE TABLE documents (
     id INT AUTO_INCREMENT PRIMARY KEY,
     url TEXT NOT NULL,
     content TEXT NOT NULL,
-    embedding VECTOR(768) NOT NULL,
+    embedding VECTOR(768) NOT NULL
 );
 ```
 

--- a/examples/with-vector-search/src/pages/index.tsx
+++ b/examples/with-vector-search/src/pages/index.tsx
@@ -326,7 +326,7 @@ const sqlCode = `CREATE TABLE documents (
     id INT AUTO_INCREMENT PRIMARY KEY,
     url TEXT NOT NULL,
     content TEXT NOT NULL,
-    embedding VECTOR(768) NOT NULL,
+    embedding VECTOR(768) NOT NULL
 );`;
 
 function Ch3({ onNext, onPrev }: { onNext: () => void; onPrev: () => void }) {


### PR DESCRIPTION
… index files

- Cleaned up the SQL code in the README.md and index.tsx files by removing unnecessary trailing whitespace in the CREATE TABLE documents statement.